### PR TITLE
OPS-2581 Correcting dup subnets logic

### DIFF
--- a/tasks/gather_facts_subnets.yml
+++ b/tasks/gather_facts_subnets.yml
@@ -75,3 +75,5 @@
     - "{{ aws_vpc_rt_subnet_by_cidr }}"
     - "{{ aws_vpc_rt_subnet_by_filter }}"
     - "{{ aws_vpc_rt_subnet_by_id }}"
+  when: not ([item] in aws_vpc_route_table_subnets)
+ 


### PR DESCRIPTION
Modified code to add a when statement that will not add a subnet to the returned list if it is already there.